### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3.5.0
       with:
         path: |
           ~/.cache/pip
           ~/.platformio/.cache
         key: ${{ runner.os }}-pio
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
       with:
         python-version: '3.11'
     - name: Install PlatformIO Core


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
