### PR TITLE
feat: outbound IPv6 in AsyncClient (DNS-family preference + happy-eyeballs-lite)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,3 +30,30 @@ jobs:
       run: pip install --upgrade platformio
     - name: Build Tests
       run: bash ./.github/scripts/on-push.sh 1 1
+
+  build-ipv6:
+    name: IPv6 lwIP build check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3.5.0
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.platformio/.cache
+        key: ${{ runner.os }}-pio
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
+      with:
+        python-version: '3.11'
+    - name: Install PlatformIO Core
+      run: pip install --upgrade platformio
+    # build-pio compiles the IPv4-only lwIP variant, so the LWIP_IPV6 code is
+    # never built there. Compile the examples against an IPv6 lwIP variant so
+    # the IPv6 paths get coverage too.
+    - name: Compile examples with the IPv6 lwIP variant
+      run: |
+        for ex in examples/ClientServer/Client examples/ClientServer/Server examples/SyncClient; do
+          python -m platformio ci -l '.' --board esp12e "$ex" --project-option="board_build.partitions = huge_app.csv"
+        done
+      env:
+        PLATFORMIO_BUILD_FLAGS: -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -257,9 +257,16 @@ u8_t AsyncClient::getDnsAddrType(){
   return _dnsAddrType;
 }
 
+// Strict opposite family of an attempt. Strict single-family types are
+// required here: the combined preference types (IPV4_IPV6 / IPV6_IPV4)
+// only order FRESH queries - a cached entry of the wrong family still
+// satisfies them, so a flip would re-fetch the very address that just
+// failed. The strict types are family-filtered against the cache and
+// force a fresh query for the other record.
 u8_t AsyncClient::_he_flipType(u8_t addrtype){
-  return (addrtype == LWIP_DNS_ADDRTYPE_IPV4_IPV6) ?
-      LWIP_DNS_ADDRTYPE_IPV6_IPV4 : LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+  bool wasV6 = (addrtype == LWIP_DNS_ADDRTYPE_IPV6_IPV4) ||
+               (addrtype == LWIP_DNS_ADDRTYPE_IPV6);
+  return wasV6 ? LWIP_DNS_ADDRTYPE_IPV4 : LWIP_DNS_ADDRTYPE_IPV6;
 }
 
 void AsyncClient::_he_setHost(const char* host, uint16_t port){

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -225,7 +225,9 @@ AsyncClient::AsyncClient(tcp_pcb* pcb):
 AsyncClient::~AsyncClient(){
   if(_pcb)
     _close();
-
+#if LWIP_IPV6
+  _he_clear();
+#endif
   _errorTracker->clearClient();
 }
 
@@ -236,6 +238,57 @@ inline void clearTcpCallbacks(tcp_pcb* pcb){
       tcp_err(pcb, NULL);
       tcp_poll(pcb, NULL, 0);
 }
+
+#if LWIP_IPV6
+u8_t AsyncClient::_dnsAddrType = LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+
+void AsyncClient::setDnsAddrType(u8_t addrtype){
+  _dnsAddrType = addrtype;
+}
+
+u8_t AsyncClient::getDnsAddrType(){
+  return _dnsAddrType;
+}
+
+void AsyncClient::_he_setHost(const char* host, uint16_t port){
+  _he_clear();
+  _he_host = strdup(host);
+  _he_flipped = false;
+  _connect_port = port;
+}
+
+void AsyncClient::_he_clear(){
+  if(_he_host){
+    ::free(_he_host);
+    _he_host = NULL;
+  }
+}
+
+// One opposite-address-family retry after a failed connect attempt.
+// The dns_addrtype fallback in connect(host, port) only covers a missing
+// DNS record; this covers a record that exists but points to an
+// unreachable path (for example a published AAAA on a network whose IPv6
+// routing is broken). Sequential, one pcb at a time.
+bool AsyncClient::_he_flip(){
+  if(!_he_host || _he_flipped){
+    return false;
+  }
+  _he_flipped = true;
+  u8_t addrtype = (_dnsAddrType == LWIP_DNS_ADDRTYPE_IPV4_IPV6) ?
+      LWIP_DNS_ADDRTYPE_IPV6_IPV4 : LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+  IPAddress addr;
+  err_t err = dns_gethostbyname_addrtype(_he_host, addr,
+      (dns_found_callback)&_s_dns_found, this, addrtype);
+  if(err == ERR_OK){
+#if ASYNC_TCP_SSL_ENABLED
+    return connect(addr, _connect_port, _pcb_secure);
+#else
+    return connect(addr, _connect_port);
+#endif
+  }
+  return (err == ERR_INPROGRESS);
+}
+#endif // LWIP_IPV6
 
 #if ASYNC_TCP_SSL_ENABLED
 bool AsyncClient::connect(IPAddress ip, uint16_t port, bool secure){
@@ -267,6 +320,9 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
 #endif
   tcp_arg(pcb, this);
   tcp_err(pcb, &_s_error);
+#if LWIP_IPV6
+  _he_connecting = true;
+#endif
   size_t err = tcp_connect(pcb, addr, port,(tcp_connected_fn)&_s_connected);
   return (ERR_OK == err);
 }
@@ -278,11 +334,13 @@ bool AsyncClient::connect(const char* host, uint16_t port){
 #endif
   IPAddress addr;
 #if LWIP_IPV6
-  // Resolve A records first, then AAAA. IPv4-first keeps hosts without
-  // IPv6 connectivity working unchanged and avoids a failing AAAA lookup
-  // ahead of every connection to the (still common) v4-only services.
+  // Resolve per the configured preference (default: A records first, then
+  // AAAA). IPv4-first keeps hosts without IPv6 connectivity working
+  // unchanged and avoids a failing AAAA lookup ahead of every connection
+  // to the (still common) v4-only services. See setDnsAddrType().
+  _he_setHost(host, port);
   err_t err = dns_gethostbyname_addrtype(host, addr,
-      (dns_found_callback)&_s_dns_found, this, LWIP_DNS_ADDRTYPE_IPV4_IPV6);
+      (dns_found_callback)&_s_dns_found, this, _dnsAddrType);
 #else
   err_t err = dns_gethostbyname(host, addr, (dns_found_callback)&_s_dns_found, this);
 #endif
@@ -475,6 +533,10 @@ void AsyncClient::_connected(std::shared_ptr<ACErrorTracker>& errorTracker, void
 
   _pcb = reinterpret_cast<tcp_pcb*>(pcb);
   if(_pcb){
+#if LWIP_IPV6
+    _he_connecting = false;
+    _he_clear();
+#endif
     _pcb_busy = false;
     _rx_last_packet = millis();
     tcp_setprio(_pcb, TCP_PRIO_MIN);
@@ -503,6 +565,10 @@ void AsyncClient::_connected(std::shared_ptr<ACErrorTracker>& errorTracker, void
 }
 
 void AsyncClient::_close(){
+#if LWIP_IPV6
+  _he_connecting = false;
+  _he_clear();
+#endif
   if(_pcb) {
 #if ASYNC_TCP_SSL_ENABLED
     if(_pcb_secure){
@@ -537,6 +603,18 @@ void AsyncClient::_error(err_t err) {
     // made to set to NULL other callbacks.
     _pcb = NULL;
   }
+#if LWIP_IPV6
+  // Happy-eyeballs-lite: a connect-phase failure gets one retry with the
+  // opposite address family before the error is surfaced.
+  if(_he_connecting && !_he_flipped && _he_host){
+    _he_connecting = false;
+    if(_he_flip()){
+      return;
+    }
+  }
+  _he_connecting = false;
+  _he_clear();
+#endif
   if(_error_cb)
     _error_cb(_error_cb_arg, this, err);
   if(_discard_cb)
@@ -721,6 +799,12 @@ void AsyncClient::_dns_found(const ip_addr *ipaddr){
     connect(ipaddr, _connect_port);
 #endif
   } else {
+#if LWIP_IPV6
+    // No record in either family (the dns_addrtype query already falls
+    // back across record types) - nothing for happy-eyeballs to retry.
+    _he_connecting = false;
+    _he_clear();
+#endif
     if(_error_cb)
       _error_cb(_error_cb_arg, this, -55);
     if(_discard_cb)

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -241,13 +241,25 @@ inline void clearTcpCallbacks(tcp_pcb* pcb){
 
 #if LWIP_IPV6
 u8_t AsyncClient::_dnsAddrType = LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+char* AsyncClient::_he_lastFailHost = NULL;
 
 void AsyncClient::setDnsAddrType(u8_t addrtype){
   _dnsAddrType = addrtype;
+  // Preference (re)set marks a configuration event: drop the failure
+  // hint so the preferred family gets a fresh chance.
+  if(_he_lastFailHost){
+    ::free(_he_lastFailHost);
+    _he_lastFailHost = NULL;
+  }
 }
 
 u8_t AsyncClient::getDnsAddrType(){
   return _dnsAddrType;
+}
+
+u8_t AsyncClient::_he_flipType(u8_t addrtype){
+  return (addrtype == LWIP_DNS_ADDRTYPE_IPV4_IPV6) ?
+      LWIP_DNS_ADDRTYPE_IPV6_IPV4 : LWIP_DNS_ADDRTYPE_IPV4_IPV6;
 }
 
 void AsyncClient::_he_setHost(const char* host, uint16_t port){
@@ -264,6 +276,20 @@ void AsyncClient::_he_clear(){
   }
 }
 
+// Remember that this host's preferred-family attempt failed so the next
+// attempt starts on the opposite family. Single slot: the common case is
+// one stubborn destination (an uploader endpoint), not many.
+void AsyncClient::_he_recordFail(){
+  if(!_he_host){
+    return;
+  }
+  if(_he_lastFailHost && strcmp(_he_lastFailHost, _he_host) == 0){
+    return;
+  }
+  ::free(_he_lastFailHost);
+  _he_lastFailHost = strdup(_he_host);
+}
+
 // One opposite-address-family retry after a failed connect attempt.
 // The dns_addrtype fallback in connect(host, port) only covers a missing
 // DNS record; this covers a record that exists but points to an
@@ -274,11 +300,10 @@ bool AsyncClient::_he_flip(){
     return false;
   }
   _he_flipped = true;
-  u8_t addrtype = (_dnsAddrType == LWIP_DNS_ADDRTYPE_IPV4_IPV6) ?
-      LWIP_DNS_ADDRTYPE_IPV6_IPV4 : LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+  _he_usedType = _he_flipType(_he_usedType);
   IPAddress addr;
   err_t err = dns_gethostbyname_addrtype(_he_host, addr,
-      (dns_found_callback)&_s_dns_found, this, addrtype);
+      (dns_found_callback)&_s_dns_found, this, _he_usedType);
   if(err == ERR_OK){
 #if ASYNC_TCP_SSL_ENABLED
     return connect(addr, _connect_port, _pcb_secure);
@@ -337,10 +362,16 @@ bool AsyncClient::connect(const char* host, uint16_t port){
   // Resolve per the configured preference (default: A records first, then
   // AAAA). IPv4-first keeps hosts without IPv6 connectivity working
   // unchanged and avoids a failing AAAA lookup ahead of every connection
-  // to the (still common) v4-only services. See setDnsAddrType().
+  // to the (still common) v4-only services. See setDnsAddrType(). If a
+  // previous attempt to this host failed on the preferred family, start
+  // on the opposite one.
   _he_setHost(host, port);
+  _he_usedType = _dnsAddrType;
+  if(_he_lastFailHost && strcmp(_he_lastFailHost, host) == 0){
+    _he_usedType = _he_flipType(_dnsAddrType);
+  }
   err_t err = dns_gethostbyname_addrtype(host, addr,
-      (dns_found_callback)&_s_dns_found, this, _dnsAddrType);
+      (dns_found_callback)&_s_dns_found, this, _he_usedType);
 #else
   err_t err = dns_gethostbyname(host, addr, (dns_found_callback)&_s_dns_found, this);
 #endif
@@ -418,6 +449,15 @@ void AsyncClient::abort(){
     _pcb = NULL;
     setCloseError(ERR_ABRT);
   }
+#if LWIP_IPV6
+  // Same reasoning as in _close(): an abort during the connect phase
+  // marks the attempted family as failed for this host.
+  if(_he_connecting && _he_host && !_he_flipped){
+    _he_recordFail();
+  }
+  _he_connecting = false;
+  _he_clear();
+#endif
   return;
 }
 
@@ -535,6 +575,12 @@ void AsyncClient::_connected(std::shared_ptr<ACErrorTracker>& errorTracker, void
   if(_pcb){
 #if LWIP_IPV6
     _he_connecting = false;
+    // Success on the preferred family clears a stale failure hint.
+    if(_he_host && _he_usedType == _dnsAddrType && _he_lastFailHost &&
+        strcmp(_he_lastFailHost, _he_host) == 0){
+      ::free(_he_lastFailHost);
+      _he_lastFailHost = NULL;
+    }
     _he_clear();
 #endif
     _pcb_busy = false;
@@ -566,6 +612,13 @@ void AsyncClient::_connected(std::shared_ptr<ACErrorTracker>& errorTracker, void
 
 void AsyncClient::_close(){
 #if LWIP_IPV6
+  // An application-initiated close/abort during the connect phase (for
+  // example an HTTP-layer timeout against a silent blackhole) counts as
+  // a failed attempt for the family-failure hint, even though lwIP never
+  // reported an error.
+  if(_he_connecting && _he_host && !_he_flipped){
+    _he_recordFail();
+  }
   _he_connecting = false;
   _he_clear();
 #endif
@@ -608,6 +661,7 @@ void AsyncClient::_error(err_t err) {
   // opposite address family before the error is surfaced.
   if(_he_connecting && !_he_flipped && _he_host){
     _he_connecting = false;
+    _he_recordFail();
     if(_he_flip()){
       return;
     }

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -398,7 +398,19 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
   _he_connecting = true;
 #endif
   size_t err = tcp_connect(pcb, addr, port,(tcp_connected_fn)&_s_connected);
-  return (ERR_OK == err);
+  if(ERR_OK != err){
+    // Synchronous connect failure (e.g. ERR_RTE with no route for the
+    // address family, ERR_MEM). lwIP did not take ownership of the pcb and
+    // will never invoke the error callback for it, so free it here or it
+    // leaks. Clear the callbacks first: tcp_abort() fires the err callback
+    // via tcp_abandon(), which would re-enter _error(ERR_ABRT).
+    // _he_connecting stays set so a caller-side _error() (the happy-
+    // eyeballs flip path) still owns flip/fail-hint handling.
+    clearTcpCallbacks(pcb);
+    tcp_abort(pcb);
+    return false;
+  }
+  return true;
 }
 
 #if ASYNC_TCP_SSL_ENABLED
@@ -895,10 +907,19 @@ void AsyncClient::_dns_found(const ip_addr *ipaddr){
 #endif
   if(ipaddr){
 #if ASYNC_TCP_SSL_ENABLED
-    connect(ipaddr, _connect_port, _pcb_secure);
+    bool connected = connect(ipaddr, _connect_port, _pcb_secure);
 #else
-    connect(ipaddr, _connect_port);
+    bool connected = connect(ipaddr, _connect_port);
 #endif
+    if(!connected && !_pcb){
+      // Synchronous connect failure after async DNS resolution (e.g.
+      // ERR_RTE: resolved family has no route). Without this the failure
+      // is silent: no connect/error/timeout callback ever fires and the
+      // application waits forever. Route it through _error() so the
+      // happy-eyeballs flip (if still armed) or the error/discard
+      // callbacks run. The !_pcb guard skips the already-connected case.
+      _error(ERR_RTE);
+    }
   } else {
 #if LWIP_IPV6
     // No record in either family (the dns_addrtype query already falls

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -252,7 +252,10 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     return false;
   }
 #endif
-  tcp_pcb* pcb = tcp_new();
+  // IP_ANY_TYPE lets tcp_connect() set the PCB address type from the
+  // destination, so the same path serves IPv4 and IPv6 peers. Matches
+  // the listening side (AsyncServer::begin).
+  tcp_pcb* pcb = tcp_new_ip_type(IPADDR_TYPE_ANY);
   if (!pcb){ //could not allocate pcb
     return false;
   }
@@ -274,7 +277,15 @@ bool AsyncClient::connect(const char* host, uint16_t port, bool secure){
 bool AsyncClient::connect(const char* host, uint16_t port){
 #endif
   IPAddress addr;
+#if LWIP_IPV6
+  // Resolve A records first, then AAAA. IPv4-first keeps hosts without
+  // IPv6 connectivity working unchanged and avoids a failing AAAA lookup
+  // ahead of every connection to the (still common) v4-only services.
+  err_t err = dns_gethostbyname_addrtype(host, addr,
+      (dns_found_callback)&_s_dns_found, this, LWIP_DNS_ADDRTYPE_IPV4_IPV6);
+#else
   err_t err = dns_gethostbyname(host, addr, (dns_found_callback)&_s_dns_found, this);
+#endif
   if(err == ERR_OK) {
 #if ASYNC_TCP_SSL_ENABLED
     return connect(addr, port, secure);

--- a/src/ESPAsyncTCP.cpp
+++ b/src/ESPAsyncTCP.cpp
@@ -241,16 +241,41 @@ inline void clearTcpCallbacks(tcp_pcb* pcb){
 
 #if LWIP_IPV6
 u8_t AsyncClient::_dnsAddrType = LWIP_DNS_ADDRTYPE_IPV4_IPV6;
-char* AsyncClient::_he_lastFailHost = NULL;
+AsyncClient::heFailHint AsyncClient::_he_failHints[AsyncClient::HE_FAIL_SLOTS] = {};
+
+// A hint is active while unexpired. millis() subtraction is
+// overflow-safe (unsigned arithmetic).
+bool AsyncClient::_he_failHintActive(const char* host){
+  if(!host){
+    return false;
+  }
+  for(int i = 0; i < HE_FAIL_SLOTS; i++){
+    if(_he_failHints[i].host && strcmp(_he_failHints[i].host, host) == 0){
+      if((millis() - _he_failHints[i].stamp) < HE_FAIL_TTL_MS){
+        return true;
+      }
+      ::free(_he_failHints[i].host);                  // Expired: retire the slot
+      _he_failHints[i].host = NULL;
+      return false;
+    }
+  }
+  return false;
+}
+
+void AsyncClient::_he_failHintClear(const char* host){
+  for(int i = 0; i < HE_FAIL_SLOTS; i++){
+    if(_he_failHints[i].host && (!host || strcmp(_he_failHints[i].host, host) == 0)){
+      ::free(_he_failHints[i].host);
+      _he_failHints[i].host = NULL;
+    }
+  }
+}
 
 void AsyncClient::setDnsAddrType(u8_t addrtype){
   _dnsAddrType = addrtype;
   // Preference (re)set marks a configuration event: drop the failure
-  // hint so the preferred family gets a fresh chance.
-  if(_he_lastFailHost){
-    ::free(_he_lastFailHost);
-    _he_lastFailHost = NULL;
-  }
+  // hints so the preferred family gets a fresh chance.
+  _he_failHintClear(NULL);
 }
 
 u8_t AsyncClient::getDnsAddrType(){
@@ -284,17 +309,34 @@ void AsyncClient::_he_clear(){
 }
 
 // Remember that this host's preferred-family attempt failed so the next
-// attempt starts on the opposite family. Single slot: the common case is
-// one stubborn destination (an uploader endpoint), not many.
+// attempts (until the TTL expires) start on the opposite family.
 void AsyncClient::_he_recordFail(){
   if(!_he_host){
     return;
   }
-  if(_he_lastFailHost && strcmp(_he_lastFailHost, _he_host) == 0){
-    return;
+  uint32_t now = millis();
+  for(int i = 0; i < HE_FAIL_SLOTS; i++){
+    if(_he_failHints[i].host && strcmp(_he_failHints[i].host, _he_host) == 0){
+      _he_failHints[i].stamp = now;                 // Refresh existing hint
+      return;
+    }
   }
-  ::free(_he_lastFailHost);
-  _he_lastFailHost = strdup(_he_host);
+  int slot = 0;                                     // Empty slot, else oldest (LRU)
+  uint32_t oldestAge = 0;
+  for(int i = 0; i < HE_FAIL_SLOTS; i++){
+    if(!_he_failHints[i].host){
+      slot = i;
+      break;
+    }
+    uint32_t age = now - _he_failHints[i].stamp;
+    if(age >= oldestAge){
+      slot = i;
+      oldestAge = age;
+    }
+  }
+  ::free(_he_failHints[slot].host);
+  _he_failHints[slot].host = strdup(_he_host);
+  _he_failHints[slot].stamp = now;
 }
 
 // One opposite-address-family retry after a failed connect attempt.
@@ -374,7 +416,7 @@ bool AsyncClient::connect(const char* host, uint16_t port){
   // on the opposite one.
   _he_setHost(host, port);
   _he_usedType = _dnsAddrType;
-  if(_he_lastFailHost && strcmp(_he_lastFailHost, host) == 0){
+  if(_he_failHintActive(host)){
     _he_usedType = _he_flipType(_dnsAddrType);
   }
   err_t err = dns_gethostbyname_addrtype(host, addr,
@@ -583,10 +625,8 @@ void AsyncClient::_connected(std::shared_ptr<ACErrorTracker>& errorTracker, void
 #if LWIP_IPV6
     _he_connecting = false;
     // Success on the preferred family clears a stale failure hint.
-    if(_he_host && _he_usedType == _dnsAddrType && _he_lastFailHost &&
-        strcmp(_he_lastFailHost, _he_host) == 0){
-      ::free(_he_lastFailHost);
-      _he_lastFailHost = NULL;
+    if(_he_host && _he_usedType == _dnsAddrType){
+      _he_failHintClear(_he_host);
     }
     _he_clear();
 #endif

--- a/src/ESPAsyncTCP.h
+++ b/src/ESPAsyncTCP.h
@@ -147,18 +147,28 @@ class AsyncClient {
 #if LWIP_IPV6
     // Happy-eyeballs-lite state: the hostname from connect(host, port) is
     // kept so a failed connect attempt can be retried once with the
-    // opposite address family (see _he_flip). _he_lastFailHost remembers
-    // the most recent host whose preferred-family connect attempt failed
-    // or was aborted, so subsequent attempts to that host start on the
-    // opposite family instead of repeating the dead one. That covers
-    // silent blackholes where the application timeout aborts the attempt
-    // before lwIP reports an error.
+    // opposite address family (see _he_flip). The failure-hint slots
+    // remember hosts whose preferred-family connect attempt failed or was
+    // aborted, so subsequent attempts to those hosts start on the opposite
+    // family instead of repeating the dead one. That covers silent
+    // blackholes where the application timeout aborts the attempt before
+    // lwIP reports an error. Hints expire after HE_FAIL_TTL_MS: while a
+    // hint is active the preferred family is never attempted, so a
+    // non-expiring hint could never clear itself and would pin the host
+    // to the fallback family until reboot. Multiple slots keep two broken
+    // destinations from evicting each other's hint and re-eating the
+    // connect timeout on every alternation.
     char* _he_host = nullptr;
     bool _he_flipped = false;
     bool _he_connecting = false;
     u8_t _he_usedType = 0;
     static u8_t _dnsAddrType;
-    static char* _he_lastFailHost;
+    static const uint32_t HE_FAIL_TTL_MS = 5 * 60 * 1000;
+    static const int HE_FAIL_SLOTS = 4;
+    struct heFailHint { char* host; uint32_t stamp; };
+    static heFailHint _he_failHints[HE_FAIL_SLOTS];
+    static bool _he_failHintActive(const char* host);
+    static void _he_failHintClear(const char* host);   // NULL clears all
     static u8_t _he_flipType(u8_t addrtype);
     void _he_setHost(const char* host, uint16_t port);
     void _he_clear();

--- a/src/ESPAsyncTCP.h
+++ b/src/ESPAsyncTCP.h
@@ -147,13 +147,22 @@ class AsyncClient {
 #if LWIP_IPV6
     // Happy-eyeballs-lite state: the hostname from connect(host, port) is
     // kept so a failed connect attempt can be retried once with the
-    // opposite address family (see _he_flip).
+    // opposite address family (see _he_flip). _he_lastFailHost remembers
+    // the most recent host whose preferred-family connect attempt failed
+    // or was aborted, so subsequent attempts to that host start on the
+    // opposite family instead of repeating the dead one. That covers
+    // silent blackholes where the application timeout aborts the attempt
+    // before lwIP reports an error.
     char* _he_host = nullptr;
     bool _he_flipped = false;
     bool _he_connecting = false;
+    u8_t _he_usedType = 0;
     static u8_t _dnsAddrType;
+    static char* _he_lastFailHost;
+    static u8_t _he_flipType(u8_t addrtype);
     void _he_setHost(const char* host, uint16_t port);
     void _he_clear();
+    void _he_recordFail();
     bool _he_flip();
 #endif
 

--- a/src/ESPAsyncTCP.h
+++ b/src/ESPAsyncTCP.h
@@ -144,6 +144,19 @@ class AsyncClient {
     u8_t _recv_pbuf_flags;
     std::shared_ptr<ACErrorTracker> _errorTracker;
 
+#if LWIP_IPV6
+    // Happy-eyeballs-lite state: the hostname from connect(host, port) is
+    // kept so a failed connect attempt can be retried once with the
+    // opposite address family (see _he_flip).
+    char* _he_host = nullptr;
+    bool _he_flipped = false;
+    bool _he_connecting = false;
+    static u8_t _dnsAddrType;
+    void _he_setHost(const char* host, uint16_t port);
+    void _he_clear();
+    bool _he_flip();
+#endif
+
     void _close();
     void _connected(std::shared_ptr<ACErrorTracker>& closeAbort, void* pcb, err_t err);
     void _error(err_t err);
@@ -205,6 +218,17 @@ class AsyncClient {
     void stop();
     void abort();
     bool free();
+
+#if LWIP_IPV6
+    // DNS resolution order for connect(host, port):
+    // LWIP_DNS_ADDRTYPE_IPV4_IPV6 (default, A record first) or
+    // LWIP_DNS_ADDRTYPE_IPV6_IPV4 (AAAA first). When the first connect
+    // attempt fails, one retry is made with the opposite order
+    // (happy-eyeballs-lite), so a published record whose path is broken
+    // degrades to a slower connect instead of a failure.
+    static void setDnsAddrType(u8_t addrtype);
+    static u8_t getDnsAddrType();
+#endif
 
     bool canSend();//ack is not pending
     size_t space();


### PR DESCRIPTION
I'm adding dual-stack IPv6 to an ESP8266 project that uses ESPAsyncTCP for its outbound connections. After #1 migrated the address handling to `IPAddress`, I found `AsyncClient` still cannot open an outbound IPv6 connection: `connect()` allocates an IPv4-only pcb with `tcp_new()` and resolves only A records, so a connect to an IPv6 host never leaves the device. This finishes that path. Everything I add is under `#if LWIP_IPV6`, so IPv4-only builds are untouched.

The change is three layers, kept as separate commits:

1. Outbound IPv6: `connect()` uses `tcp_new_ip_type(IPADDR_TYPE_ANY)` (matching the listening side in `AsyncServer::begin`) and resolves names with `dns_gethostbyname_addrtype`.
2. DNS-family preference and happy-eyeballs-lite: `setDnsAddrType()`/`getDnsAddrType()` select A-first (the default) or AAAA-first; a failed connect retries once on the opposite family, and a TTL'd hint table remembers a host whose preferred family is a dead path, including the case where an application-layer timeout aborts the attempt before lwIP reports an error.
3. Two robustness fixes I left outside the `#if LWIP_IPV6` guard because they apply to all builds: I free the pcb on a synchronous `tcp_connect` failure (it was leaked before), and I route a post-DNS synchronous connect failure through `_error()` so it surfaces instead of hanging with no callback. I kept these as their own commit since they change the existing IPv4 path.

I also noticed `build-pio` compiles only the IPv4-only lwIP variant, so the IPv6 code here would never be built in CI. I added a `build-ipv6` job that compiles the examples against an IPv6 lwIP variant, mirroring the existing job's setup and pinned action SHAs. I verified both the IPv4-only build and the IPv6 build compile.

The commits are split along these layers, so if you would rather take this as separate PRs I am glad to break it up.
